### PR TITLE
fix bug: wrong convert from snake_case

### DIFF
--- a/src/components/templates/CaseConverterView.vue
+++ b/src/components/templates/CaseConverterView.vue
@@ -63,7 +63,7 @@ export default {
       kebabCase: '',
       pascalCase: '',
       upperSnakeCase: '',
-      isAlert: true
+      isAlert: false
     }
   },
   mounted () {

--- a/src/constants.js
+++ b/src/constants.js
@@ -1,5 +1,5 @@
-export const NON_VARIABLE_CHAR_REGEX = /[^A-z0-9$]/g
-export const CAMEL_CASE = /^[a-z$_]+([A-Z][a-z0-9]*)*$/
+export const NON_VARIABLE_CHAR_REGEX = /[^A-Za-z0-9$]/g
+export const CAMEL_CASE = /^(([a-z$]+)|([_][a-z$]+)){1}([A-Z][a-z0-9]*)*$/
 export const PASCAL_CASE = /^([A-Z$_][a-z0-9]*)+$/
 export const SNAKE_CASE = /^([a-z$]+_?)([a-z0-9]+_)*[a-z0-9]+$/
 export const UPPER_SNAKE_CASE = /^([A-Z$]+_?)([A-Z0-9]+_)*[A-Z0-9]+$/


### PR DESCRIPTION
- description:
  - snake_case => snake-_case (kebab); Snake_case (pascal); snake_case (camel);

- reason:
  - regex of camelCase matched 'snake_case' then it converted from camel case